### PR TITLE
Fix download url of zig releases

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -18,7 +18,7 @@ get_url() {
   else
     url=$( \
       curl -s $BASE_URL \
-      | sed -n 's/"tarball": "\(.*zig-'"$platform"'-'"$arch"'-'"$version"'\.tar.*\)",/\1/p' \
+      | sed -n 's/"tarball": "\(.*\/download\/'"$version"'\/zig-'"$platform"'-'"$arch"'-'"$version"'\.tar.*\)",/\1/p' \
     )
   fi
 

--- a/bin/list-all
+++ b/bin/list-all
@@ -10,7 +10,7 @@ get_versions() {
   local versions=""
   versions=$( \
     curl -s $BASE_URL \
-    | sed -n 's/"tarball": ".*zig-'"$platform"'-'"$arch"'-\([0-9\.]*\).tar.*",/\1/p' \
+    | sed -n 's/"tarball": ".*\/download\/.*\/zig-'"$platform"'-'"$arch"'-\([0-9\.]*\).tar.*",/\1/p' \
     | sed -e 's/^[[:space:]]*//' \
     | sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n \
     | tr '\n' ' ' \


### PR DESCRIPTION
The downloadable releases are under the /download/ path. When running
the old sed expression it also returned values from the /builds/ path,
which lead to an issue with downloading the tar file.

This will fix issue #1 