### PR TITLE
Replace ceased travis-ci.org with GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'daily'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  plugin_test:
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: asdf-vm/actions/plugin-test@v1
+        with:
+          command: 'zig version'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: c
-script: asdf plugin-test zig . 'zig version'
-before_script:
-  - git clone https://github.com/asdf-vm/asdf.git
-  - . asdf/asdf.sh
-os:
-  - linux
-  - osx

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/cheetah/asdf-zig.svg?branch=master)](https://travis-ci.org/cheetah/asdf-zig)
+[![Build Status](https://github.com/cheetah/asdf-zig/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/cheetah/asdf-zig/actions/workflows/build.yml?query=branch%3Amaster)
 
 # asdf-zig
 [zig](https://ziglang.org/) plugin for [asdf version manager](https://github.com/asdf-vm/asdf)


### PR DESCRIPTION
https://blog.travis-ci.com/2021-05-07-orgshutdown


Looks current CI and badge does not show latest status.

<img width="884" alt="スクリーンショット 2022-11-01 041331" src="https://user-images.githubusercontent.com/1180335/199090857-cff36ec0-cb62-4093-ac0d-83c6965011b9.png">

How about to replace with GitHub Actions? 

This change has been tested in my repository, it looks worked. 

- https://github.com/kachick/cheetah-asdf-zig/pull/1
- https://github.com/kachick/cheetah-asdf-zig/actions/runs/3364042139/jobs/5577933413
- https://github.com/kachick/cheetah-asdf-zig/actions/runs/3364042139/jobs/5577933520