### PR TITLE
feat: allow installing exact version

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -15,6 +15,8 @@ get_url() {
       curl -s $BASE_URL \
       | sed -n 's/"tarball": "\(.*\/builds\/.*zig-'"$platform"'-'"$arch"'-[0-9\.]*.*\)",/\1/p' \
     )
+  elif [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+-dev.[0-9]+\+[0-9a-f]+$ ]]; then
+    url="https://ziglang.org/builds/zig-$platform-$arch-$version.tar.xz"
   else
     url=$( \
       curl -s $BASE_URL \


### PR DESCRIPTION
This PR adds support for installing an exact version of zig, e.g.:

```
# mise use zig@0.12.0-dev.1754+2a3226453
```

PS: using [mise](https://github.com/jdx/mise) here, but works the same with asdf.