### PR TITLE
fix: allow downloading release from builds directory

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -20,7 +20,7 @@ get_url() {
   else
     url=$( \
       curl -s $BASE_URL \
-      | sed -n 's/"tarball": "\(.*\/\(download\|builds\)\/.*zig-'"$platform"'-'"$arch"'-'"$version"'\.tar.*\)",/\1/p' \
+      | sed -E -n 's/"tarball": "(.*\/(download|builds)\/.*zig-'"$platform"'-'"$arch"'-'"$version"'\.tar.*)",/\1/p' \
     )
   fi
 

--- a/bin/install
+++ b/bin/install
@@ -20,7 +20,7 @@ get_url() {
   else
     url=$( \
       curl -s $BASE_URL \
-      | sed -n 's/"tarball": "\(.*\/download\/.*zig-'"$platform"'-'"$arch"'-'"$version"'\.tar.*\)",/\1/p' \
+      | sed -n 's/"tarball": "\(.*\/\(download\|builds\)\/.*zig-'"$platform"'-'"$arch"'-'"$version"'\.tar.*\)",/\1/p' \
     )
   fi
 


### PR DESCRIPTION
This PR allows retrieving release builds from either `download` or `builds` directory.

This is needed because 0.12.1 comes from https://ziglang.org/builds/zig-linux-x86_64-0.12.1.tar.xz in https://ziglang.org/download/index.json