### PR TITLE
Fix: Zig Package Download URL Parsing for Recent Releases

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -13,14 +13,16 @@ get_url() {
   if [ "master" = "$version" ]; then
     url=$( \
       curl -s $BASE_URL \
-      | sed -n 's/"tarball": "\(.*\/builds\/.*zig-'"$platform"'-'"$arch"'-[0-9\.]*.*\)",/\1/p' \
+      | grep 'tarball' | grep 'dev' | grep $arch | grep $platform \
+      | sed -n 's/"tarball": "\(.*\/builds\/.*zig-.*-[0-9\.]*.*\)",/\1/p' \
     )
   elif [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+-dev.[0-9]+\+[0-9a-f]+$ ]]; then
     url="https://ziglang.org/builds/zig-$platform-$arch-$version.tar.xz"
   else
     url=$( \
       curl -s $BASE_URL \
-      | sed -E -n 's/"tarball": "(.*\/(download|builds)\/.*zig-'"$platform"'-'"$arch"'-'"$version"'\.tar.*)",/\1/p' \
+      | grep 'tarball' | grep -v 'dev' | grep $arch | grep $platform \
+      | sed -E -n 's/"tarball": "(.*\/(download|builds)\/.*zig-.*-'"$version"'\.tar.*)",/\1/p' \
     )
   fi
 

--- a/bin/list-all
+++ b/bin/list-all
@@ -10,7 +10,8 @@ get_versions() {
   local versions=""
   versions=$( \
     curl -s $BASE_URL \
-    | sed -n 's/"tarball": ".*\/download\/.*zig-'"$platform"'-'"$arch"'-\([0-9\.]*\).tar.*",/\1/p' \
+    | grep 'tarball' | grep $arch | grep $platform \
+    | sed -n 's/"tarball": ".*\/download\/.*zig-.*-\([0-9\.]*\).tar.*",/\1/p' \
     | sed -e 's/^[[:space:]]*//' \
     | sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n \
     | tr '\n' ' ' \


### PR DESCRIPTION
Adapt the download URL parsing logic to ensure compatibility with the official JSON listing indexes provided by ziglang.org

This patch addresses an issue with the current plugin's URL parsing mechanism for Zig package downloads. Recently, the Zig project modified their download URL format by swapping the positions of `$platform` and `$arch` parameters.